### PR TITLE
Refactor damage prevention comment in BossFight.cpp

### DIFF
--- a/BossFight/BossFight.cpp
+++ b/BossFight/BossFight.cpp
@@ -315,7 +315,7 @@ public:
     }
 
     void takeDamage(int amount) {
-        // Prevent taking damage if already dead, or already in the hurt state (prevents chain-stuns)
+        // Prevent taking damage if already dead, or already in the hurt state
         if (!isAlive() || animations.getCurrentState() == AnimationState::Dead || isHurt) {
             return;
         }


### PR DESCRIPTION
Removed a commented-out debug statement and clarified the conditions for preventing damage. 